### PR TITLE
Fixed naming issues in reference_controller.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ This is a project for Software Engineering course in the fall of 2022 at Helsink
 
 __Definition of Done__
 
-Toteutetun User storyn toiminnallisuus on ohjelmoitu ja viety tuotantoon. 
-Testikattavuus on 90%, testitapaukset ovat mielekkäitä. 
+Toteutetun User storyn toiminnallisuus on ohjelmoitu ja viety tuotantoon.
+Testikattavuus on 90%, testitapaukset ovat mielekkäitä.
 Testit menevät läpi. Pylint ei havaitse koodissa virheitä.
 
 __Sprint reviews__
@@ -70,3 +70,4 @@ __Manual orchestration__
     * Start test server if one exists and is not running.
   * `invoke stop_test_server`
     * Stop test server container if one exists and is running.
+

--- a/app/controllers/reference_controller.py
+++ b/app/controllers/reference_controller.py
@@ -4,9 +4,9 @@ from app.models.field import Field
 from sqlalchemy import select, delete
 
 
-def get_by_id(id):
+def get_by_id(id_):
     return db.session.execute(
-        select(Reference).where(Reference.id == id)
+        select(Reference).where(Reference.id == id_)
     ).scalar_one()
 
 
@@ -20,21 +20,21 @@ def get_titles():
             Field.name == "title").all()
 
 
-def create(name, type, fields={}):
+def create(name, type_, fields={}):
     if len(name) == 0:
         raise ValueError("Name is invalid")
     if len(type) == 0:
         raise ValueError("Type is unknown")
 
-    reference = Reference(name=name, type=type)
+    reference = Reference(name=name, type=type_)
 
-    for name, content in fields.items():
-        reference.fields.append(Field(name=name, content=content))
+    for ref_name, content in fields.items():
+        reference.fields.append(Field(name=ref_name, content=content))
 
     db.session.add(reference)
     db.session.commit()
 
 
-def delete_by_id(id):
-    db.session.execute(delete(Reference).where(Reference.id == id))
+def delete_by_id(id_):
+    db.session.execute(delete(Reference).where(Reference.id == id_))
     db.session.commit()


### PR DESCRIPTION
For week 6 exercise 6. Added underscore to end of variable names using built in names such as `id` or `type` according to [pep-8](https://peps.python.org/pep-0008/#descriptive-naming-styles). Also fixed a redefining of variable `name` in function `create` to prevent errors in the future.